### PR TITLE
Fixes JSON call Disconnections (Palettes & Effects not updating)

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -260,7 +260,7 @@ class BasePlugin:
             self._getWLEDJSON()
 
     def _getWLEDJSON(self):
-        Domoticz.Log("_getWLEDJSON")
+        #Domoticz.Log("_getWLEDJSON")
         self.JSONConn = Domoticz.Connection(Name="JSONConn", Transport="TCP/IP", Protocol="HTTP", Address=ipaddress, Port="80" )
         self.JSONConn.Connect()
 

--- a/plugin.py
+++ b/plugin.py
@@ -92,7 +92,8 @@ class BasePlugin:
 
         UpdatePresetsInDomoticz()
 
-        getWLEDJSON( self.JSONConn )
+        self._getWLEDJSON()
+
 
     def onStop(self):
         Domoticz.Log("onStop called")
@@ -256,7 +257,12 @@ class BasePlugin:
 
         if( self.counter > updateInterval ):
             self.counter = 1
-            getWLEDJSON( self.JSONConn )
+            self._getWLEDJSON()
+
+    def _getWLEDJSON(self):
+        Domoticz.Log("_getWLEDJSON")
+        self.JSONConn = Domoticz.Connection(Name="JSONConn", Transport="TCP/IP", Protocol="HTTP", Address=ipaddress, Port="80" )
+        self.JSONConn.Connect()
 
 global _plugin
 _plugin = BasePlugin()
@@ -411,10 +417,7 @@ def UpdateStatusInDomoticz():
 #   Domoticz.Log( "preset:" + str(preset) )
 #   UpdateDevice(4,1,int(wledData["preset"]*10)) 
 
-def getWLEDJSON( JSONConn ):
-    #Domoticz.Log("getWLEDJSON")
-    JSONConn = Domoticz.Connection(Name="JSONConn", Transport="TCP/IP", Protocol="HTTP", Address=ipaddress, Port="80" )
-    JSONConn.Connect()
+
 
 def doWLEDRequest( parameters ):
     global ipaddress


### PR DESCRIPTION
Hi,

first thanks for this excellent Plugin 🍺 
You said that it was you first python plugin, and first experience on Github... It seems that you've learnt really fast 😎 

------

Following
https://domoticz.com/forum/viewtopic.php?f=65&start=80&t=29669
+ fixes #13 
+ fixes #14

**Current Bug:**
Palettes and Effects selectors dont get updated, and this is shown in the log:

`Error: (Wled) Transport is not connected, write directive to 'JSONConn' ignored.`
or
`Error: (Wled) No transport, write directive to 'JSONConn' ignored.`

Looking at detailed log, this is due to the connection being dropped (disconnected) BEFORE getting a chance to be read.

According to the [official plug-in documentation](https://www.domoticz.com/wiki/Developing_a_Python_plugin#Connections):
_"Connections remain active only while they are in scope in Python after that Domoticz will actively disconnect them so plugins should store Connections that they want to keep in global or class variables."_ 

In this PR, I've moved the **getWLEDJSON** into the plugin class, so that the connection is no longer automatically disconnected by Domoticz...


(Tested on latest Beta 2021.1 build 13949)
