### PR TITLE
Bump Plugin Version

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -3,7 +3,7 @@
 # Author: Frustreermeneer
 #
 """
-<plugin key="WLED" name="WLED" author="frustreermeneer" version="0.0.1" wikilink="http://www.domoticz.com/wiki/plugins/plugin.html" externallink="https://github.com/frustreermeneer/domoticz-wled-plugin">
+<plugin key="WLED" name="WLED" author="frustreermeneer" version="0.0.2" wikilink="http://www.domoticz.com/wiki/plugins/plugin.html" externallink="https://github.com/frustreermeneer/domoticz-wled-plugin">
     <description>
         <h2>WLED Plugin</h2><br/>
         <h3>Features</h3>


### PR DESCRIPTION
Following my #15 merged PR, I first thought that you'd have incremented the plugin-version yourself.

As you said that you no longer maintain it, this simple one-click-merge PR set version to 0.0.2 so users wont get confused about the version they're currently using.

HTH